### PR TITLE
refactor: pin pixelpass dependency to v1.0.0-alpha.1 tag

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mosip/pixelpass-ios-swift.git",
       "state" : {
-        "branch" : "release-1.0.x",
-        "revision" : "c52ad3d13f056489ceaa6d291a5395353f18491e"
+        "revision" : "15b41b878cc3507c167748f92fa6abe9a49cd3c0",
+        "version" : "1.0.0-alpha.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
             targets: ["InjiVcRenderer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/mosip/pixelpass-ios-swift.git", branch: "release-1.0.x"),
+        .package(url: "https://github.com/mosip/pixelpass-ios-swift.git", exact: "1.0.0-alpha.1"),
         .package(url: "https://github.com/tadija/AEXML.git", from: "4.6.0")
 
     ],


### PR DESCRIPTION
`pixelpass-ios-swift` is now tagged `v1.0.0-alpha.1`, so this replaces the `release-1.0.x` branch dependency with an exact version pin for a reproducible release build. 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PixelPass iOS dependency to use the fixed `1.0.0-alpha.1` release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->