### PR TITLE
fix: update pixelpass pinned revision to corrected v1.0.0-alpha.1 tag

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -23,7 +23,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/mosip/pixelpass-ios-swift.git",
       "state" : {
-        "revision" : "15b41b878cc3507c167748f92fa6abe9a49cd3c0",
+        "revision" : "0f6223ef65012260d93ec4a2273ca9f14be2a2a5",
         "version" : "1.0.0-alpha.1"
       }
     },


### PR DESCRIPTION
Follow-up to #23. The `v1.0.0-alpha.1` tag on `pixelpass-ios-swift` was re-cut from `release-1.0.x`, so the revision recorded in `Package.resolved` was stale and failed resolution with a tag-mismatch error.

